### PR TITLE
Update FileList.module.css

### DIFF
--- a/file-upload-frontend/src/components/FileList.module.css
+++ b/file-upload-frontend/src/components/FileList.module.css
@@ -53,7 +53,7 @@ svg {
 }
 
 .file-delete {
-  flex: 40%;
+  margin-right: 20px;
 }
 
 .delete-button {
@@ -85,5 +85,10 @@ svg {
   .filelist {
     width: 50%;
     margin: auto;
+  }
+
+  .filelist > ul {
+    max-width: 600px;
+    margin: 0 auto 20px auto;
   }
 }


### PR DESCRIPTION
Update the FileList component styling, the distance between the trash bin svg to the right side of the element was off in comparison to the name and pdf svg to the left side of the element. This became apparent the wider the viewport got.